### PR TITLE
feat(styles): enforce plaintext Unicode bidi for all elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .env
 docker/mysql
+cache

--- a/styles/css304/style.css
+++ b/styles/css304/style.css
@@ -1,4 +1,5 @@
 /* Start css for PBBoard 3.0.4 */
+*{unicode-bidi: plaintext;}
 .smiles-bbcode{
 width:13%;
 vertical-align: top;

--- a/styles/css304/style_ltr.css
+++ b/styles/css304/style_ltr.css
@@ -1,4 +1,5 @@
 /* Start css for PBBoard 3.0.4 */
+*{unicode-bidi: plaintext;}
 .smiles-bbcode{
 width:13%;
 vertical-align: top;

--- a/styles/style_default/css/style.css
+++ b/styles/style_default/css/style.css
@@ -1,3 +1,4 @@
+*{unicode-bidi: plaintext;}
 body,html {
 margin: 0;
 padding: 0;

--- a/styles/style_default/css/style_ltr.css
+++ b/styles/style_default/css/style_ltr.css
@@ -1,3 +1,4 @@
+*{unicode-bidi: plaintext;}
 body,html {
 margin: 0;
 padding: 0;


### PR DESCRIPTION
## Description:
This merge request introduces a global CSS rule to enforce `unicode-bidi: plaintext` on all elements. This ensures that text directionality is handled at the character level, preventing unwanted bidirectional text issues.

## Changes:

Added the following CSS rule:

```css
* {
    unicode-bidi: plaintext;
}
```

## Reason for Change:

- Improves handling of mixed-direction text, particularly in multilingual applications.

- Ensures better text rendering consistency across different browsers.

## Testing:

- Verified text behavior in different RTL and LTR scenarios.

- Ensured no unexpected layout issues occurred due to this change.

## Impact:

- Affects all elements on the page.

- Should be tested in environments with mixed-direction content.


## Comparison (Before & After)

| Before (`unicode-bidi` not applied) | After (`unicode-bidi: plaintext;` applied) |
|-------------------------------------|------------------------------------------|
| <img width="389" alt="Before" src="https://github.com/user-attachments/assets/b448bbc3-2c24-49f6-a16e-4e0dcbb38583" /> | <img width="363" alt="After" src="https://github.com/user-attachments/assets/b7cbeb32-20e0-49d4-a092-91db73813937" /> |
